### PR TITLE
Update fluentd 0.14.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,14 +9,14 @@ RUN apk --no-cache --update add \
                             ruby-dev && \
     echo 'gem: --no-document' >> /etc/gemrc && \
     gem install oj json && \
-    gem install fluentd -v 0.14.8 && \
+    gem install fluentd -v 0.14.11 && \
     apk del build-base ruby-dev && \
     rm -rf /tmp/* /var/tmp/* /var/cache/apk/* /usr/lib/ruby/gems/*/cache/*.gem
 
 RUN mkdir -p /etc/fluent/plugin && mkdir -p /data/buffer && mkdir /data/pos && mkdir /data/log
 COPY plugin /etc/fluent/plugin/
 
-ENV DOCKERIZE_VERSION v0.2.0
+ENV DOCKERIZE_VERSION v0.3.0
 
 RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && \
     tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && \


### PR DESCRIPTION
http://www.fluentd.org/blog/fluentd-v0.14.9-has-been-released
Breaking change: `time_as_integer` parameter is now false