### PR TITLE
Temporary disable require_ack_response

### DIFF
--- a/fluent.tmpl
+++ b/fluent.tmpl
@@ -149,7 +149,7 @@
   @type forward
   heartbeat_type transport
   heartbeat_interval 1s
-  require_ack_response true
+  #require_ack_response true
 
   <buffer tag>
     @type file


### PR DESCRIPTION
https://github.com/fluent/fluentd/issues/1665
This is a fatal problem and has not been fixed yet.

Comment out require_ack_response until it is fixed

(However, it is not certain whether solved by this)