### PR TITLE
Disable heartbeat

### DIFF
--- a/fluent.tmpl
+++ b/fluent.tmpl
@@ -147,8 +147,7 @@
 <match *.**>
   @id forward_any
   @type forward
-  heartbeat_type transport
-  heartbeat_interval 1s
+  heartbeat_type none
   #require_ack_response true
 
   <buffer tag>


### PR DESCRIPTION
* it makes no sense to use heartbeat because flush_interval is 1s
* When using dns_round_robin, heartbeat should be tcp or none.